### PR TITLE
Auto nav to comments after invoice

### DIFF
--- a/src/nostr/zapLogic.ts
+++ b/src/nostr/zapLogic.ts
@@ -133,7 +133,7 @@ export const publishCommentEvent = async ({
   publishEvent: (event: Event) => void;
 }) => {
   try {
-    const commenterPubKey = await window.nostr?.getPublicKey() || "";
+    const commenterPubKey = (await window.nostr?.getPublicKey()) || "";
     const unsigned: UnsignedEvent = {
       kind: 1,
       content,

--- a/src/pages/WavmanPlayer.tsx
+++ b/src/pages/WavmanPlayer.tsx
@@ -92,11 +92,15 @@ const WavmanPlayer: React.FC<{}> = ({}) => {
   const [paymentRequest, setpaymentRequest] = useState("");
 
   // ZapReceipt Listener
-  const skipZapReceipts = !kind1NowPlaying?.id
-  const { allEvents: zapReceipts, lastEvent: lastZapReceipt, loading: zapReceiptsLoading } =
-    useEventSubscription([
-      { kinds: [9735], ["#e"]: [kind1NowPlaying?.id || ''] },
-    ], skipZapReceipts);
+  const skipZapReceipts = !kind1NowPlaying?.id;
+  const {
+    allEvents: zapReceipts,
+    lastEvent: lastZapReceipt,
+    loading: zapReceiptsLoading,
+  } = useEventSubscription(
+    [{ kinds: [9735], ["#e"]: [kind1NowPlaying?.id || ""] }],
+    skipZapReceipts
+  );
 
   // Get track comments, skip till a track is ready
   const skipComments = !kind1NowPlaying;
@@ -220,7 +224,8 @@ const WavmanPlayer: React.FC<{}> = ({}) => {
   };
 
   useEffect(() => {
-    const [bolt11, lastPaymentRequest] = lastZapReceipt?.tags.find(([tagName]) => tagName === "bolt11") || [];
+    const [bolt11, lastPaymentRequest] =
+      lastZapReceipt?.tags.find(([tagName]) => tagName === "bolt11") || [];
     // If user is on the QR_VIEW and a zap receipt is received for the current payment request
     if (currentPage === QR_VIEW && paymentRequest === lastPaymentRequest) {
       setPageViewAndResetSelectedAction(COMMENTS_VIEW);

--- a/src/pages/WavmanPlayer.tsx
+++ b/src/pages/WavmanPlayer.tsx
@@ -7,6 +7,7 @@ import {
   ZAP_AMOUNT_VIEW,
   ZAP_COMMENT_VIEW,
   coerceEnvVarToBool,
+  COMMENTS_VIEW,
 } from "../lib/shared";
 import Logo from "./Logo";
 import Button from "./PlayerControls/Button";
@@ -86,7 +87,7 @@ const WavmanPlayer: React.FC<{}> = ({}) => {
 
   // ZapReceipt Listener
   const skipZapReceipts = !kind1NowPlaying?.id
-  const { allEvents: zapReceipts, loading: zapReceiptsLoading } =
+  const { allEvents: zapReceipts, lastEvent: lastZapReceipt, loading: zapReceiptsLoading } =
     useEventSubscription([
       { kinds: [9735], ["#e"]: [kind1NowPlaying?.id || ''] },
     ], skipZapReceipts);
@@ -201,21 +202,23 @@ const WavmanPlayer: React.FC<{}> = ({}) => {
         setPageViewAndResetSelectedAction(ZAP_AMOUNT_VIEW);
         return;
       }
-      const { enabled } = await window.webln?.enable() || {};
-      if (enabled) {
-        // use webLN to pay
-        try {
-          await window.webln?.sendPayment(invoice);
-        } catch (e) {
-          // failed to pay invoice, present QR code
-          setpaymentRequest(invoice);
-        }
-      } else {
-        // webLN not available? present QR code
-        setpaymentRequest(invoice);
+      setpaymentRequest(invoice);
+      try {
+        await window.webln?.sendPayment(invoice);
+      } catch (e) {
+        console.log("Error paying via webln:", e);
       }
     }
   };
+
+  useEffect(() => {
+    const [bolt11, lastPaymentRequest] = lastZapReceipt?.tags.find(([tagName]) => tagName === "bolt11") || [];
+    // If user is on the QR_VIEW and a zap receipt is received for the current payment request
+    if (currentPage === QR_VIEW && paymentRequest === lastPaymentRequest) {
+      setPageViewAndResetSelectedAction(COMMENTS_VIEW);
+    }
+  }, [lastZapReceipt, paymentRequest]);
+
   const [nowPlayingTrackContent] = kind32123NowPlaying || [];
   return (
     // Page Container


### PR DESCRIPTION
Listen for zap receipt, once the current invoice in context is paid, navigate away from invoice screen to the comments screen