### PR TITLE
Swap listEvents for eventSubcription

### DIFF
--- a/src/pages/WavmanPlayer.tsx
+++ b/src/pages/WavmanPlayer.tsx
@@ -243,7 +243,12 @@ const WavmanPlayer: React.FC<{}> = ({}) => {
     }
   }, [lastZapReceipt, paymentRequest]);
 
-  const [nowPlayingTrackContent] = kind32123NowPlaying || [];
+  if (!kind32123NowPlaying.length) {
+    console.error("No associated 32123 event found for this track:", kind1NowPlaying);
+    skipHandler();
+  };
+  const [nowPlayingTrackContent] = kind32123NowPlaying;
+
   return (
     // Page Container
     <>

--- a/src/pages/WavmanPlayer.tsx
+++ b/src/pages/WavmanPlayer.tsx
@@ -79,8 +79,6 @@ const WavmanPlayer: React.FC<{}> = ({}) => {
     kind1NowPlaying?.tags?.find(([tagType]) => tagType === "a") || [];
   const kind32123DTag = kind1ATag?.replace("32123:", "")?.split(":")?.[1];
   const skipKind32123 = !kind32123DTag;
-
-  if (skipKind32123) console.error("D tag not found for the current track:", kind1NowPlaying);
   // get the kind 1's replaceable 32123 event
   // TODO implement replaceability and test to make sure the most recent is consumed here
   const { allEvents: kind32123NowPlaying, loading: kind32123NowPlayingLoading } =
@@ -243,10 +241,6 @@ const WavmanPlayer: React.FC<{}> = ({}) => {
     }
   }, [lastZapReceipt, paymentRequest]);
 
-  if (!kind32123NowPlaying.length) {
-    console.error("No associated 32123 event found for this track:", kind1NowPlaying);
-    skipHandler();
-  };
   const [nowPlayingTrackContent] = kind32123NowPlaying;
 
   return (


### PR DESCRIPTION
The listEvents function from `useRelay` was receiving a `CLOSE` event from the relay, which was causing the player to display the splash screen because there was no `kind32123NowPlaying` available.

I swapped these for `eventSubscription` calls instead.