### PR TITLE
Add modal for mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 ## Getting Started
 
 Clone this repo with the following command:
+
 ```bash
 git clone https://github.com/wavlake/wavman.git
 ```
 
 Once inside the newly cloned repo folder (`cd wavman`) install dependencies:
+
 ```bash
 npm install
 # or

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "wavman",
       "version": "0.1.0",
       "dependencies": {
+        "@headlessui/react": "^1.7.14",
         "@types/node": "18.15.11",
         "@types/react": "18.0.32",
         "@types/react-dom": "18.0.11",
@@ -543,6 +544,21 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.14",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.14.tgz",
+      "integrity": "sha512-znzdq9PG8rkwcu9oQ2FwIy0ZFtP9Z7ycS+BAqJ3R5EIqC/0bJGvhT7193rFf+45i9nnPsYvCQVW4V/bB9Xc+gA==",
+      "dependencies": {
+        "client-only": "^0.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5639,6 +5655,14 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
       "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
       "dev": true
+    },
+    "@headlessui/react": {
+      "version": "1.7.14",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.14.tgz",
+      "integrity": "sha512-znzdq9PG8rkwcu9oQ2FwIy0ZFtP9Z7ycS+BAqJ3R5EIqC/0bJGvhT7193rFf+45i9nnPsYvCQVW4V/bB9Xc+gA==",
+      "requires": {
+        "client-only": "^0.0.1"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prettify": "npx prettier --write ."
   },
   "dependencies": {
+    "@headlessui/react": "^1.7.14",
     "@types/node": "18.15.11",
     "@types/react": "18.0.32",
     "@types/react-dom": "18.0.11",

--- a/src/nostr/zapLogic.ts
+++ b/src/nostr/zapLogic.ts
@@ -7,9 +7,7 @@ import {
   signAnonZapEvent,
   sendZapRequestReceivePaymentRequest,
 } from "./zapUtils";
-import {
-  Event,
-} from "nostr-tools";
+import { Event } from "nostr-tools";
 
 export const getInvoice = async ({
   nowPlayingTrack,
@@ -45,8 +43,8 @@ export const getInvoice = async ({
           recepientPubKey: nostrPubKey,
           zappedEvent: nowPlayingTrack,
           pubkey: nip07PubKey,
-        })
-        
+        });
+
         return sendZapRequestReceivePaymentRequest({
           signedZapEvent,
           callback,
@@ -58,7 +56,9 @@ export const getInvoice = async ({
       }
     } catch (e) {
       console.error(e);
-      console.log("Unable to sign event with NIP-07, falling back to an anon zap");
+      console.log(
+        "Unable to sign event with NIP-07, falling back to an anon zap"
+      );
       const signedZapEvent = await signAnonZapEvent({
         content,
         amount,

--- a/src/pages/Nip07InfoModal.tsx
+++ b/src/pages/Nip07InfoModal.tsx
@@ -40,9 +40,9 @@ const Nip07InfoModal: React.FC<{
             <Dialog.Panel className="mx-auto max-w-md rounded bg-white p-2">
               <Dialog.Title className="pb-4 text-center">NIP-07</Dialog.Title>
               <Dialog.Description className="text-xs">
-                Looks like you don't have a NIP-07 extension installed. On
+                {`Looks like you don't have a NIP-07 extension installed. On
                 mobile? Try this on a desktop browser with a NIP-07 extension
-                (like Alby) installed.{" "}
+                (like Alby) installed.`}
                 <Link href="https://github.com/nostr-protocol/nips/blob/master/07.md">
                   Click here
                 </Link>{" "}

--- a/src/pages/Nip07InfoModal.tsx
+++ b/src/pages/Nip07InfoModal.tsx
@@ -15,11 +15,12 @@ const Nip07InfoModal: React.FC<{
         setCommenterPubKey(pubKey);
         return;
       }
+      // show modal if pubKey code above is undefined
+      setIsOpen(!isOpen)
     } catch (e) {
+      // don't show modal if user rejects the NIP-07 extension's prompt
       console.error(e)
     }
-
-    setIsOpen(!isOpen)
   }
 
   // if (commenterPubKey) return <></>;
@@ -33,18 +34,22 @@ const Nip07InfoModal: React.FC<{
         {commenterPubKey ? "LOGGED IN" : "NIP-07 LOGIN"}
       </Button>
       <Dialog open={isOpen} onClose={() => setIsOpen(false)}>
-        <Dialog.Panel>
-          <Dialog.Title>NIP-07</Dialog.Title>
-          <Dialog.Description>
-            Looks like you don't have a NIP-07 extension installed. On mobile? Try this on a desktop browser with a extension like Alby installed. Read more about NIP-07 here https://github.com/nostr-protocol/nips/blob/master/07.md
-            <Button
-              className="mx-auto mt-4 w-28 self-start bg-wavgray hover:tracking-wider"
-              clickHandler={() => setIsOpen(false)}
-            >
-              OK
-            </Button>
-          </Dialog.Description>
-        </Dialog.Panel>
+        <div className="fixed inset-0 bg-black/30" aria-hidden="true">
+          <div className="fixed inset-0 flex items-center justify-center p-4">
+            <Dialog.Panel className="mx-auto max-w-sm rounded bg-white">
+              <Dialog.Title>NIP-07</Dialog.Title>
+              <Dialog.Description>
+                Looks like you don't have a NIP-07 extension installed. On mobile? Try this on a desktop browser with a extension like Alby installed. Read more about NIP-07 here https://github.com/nostr-protocol/nips/blob/master/07.md
+              </Dialog.Description>
+              <Button
+                className="mx-auto mt-4 w-28 self-start bg-wavgray hover:tracking-wider"
+                clickHandler={() => setIsOpen(false)}
+              >
+                OK
+              </Button>
+            </Dialog.Panel>
+          </div>
+        </div>
       </Dialog>
     </>
   )

--- a/src/pages/Nip07InfoModal.tsx
+++ b/src/pages/Nip07InfoModal.tsx
@@ -1,28 +1,28 @@
-import { Dispatch, MouseEventHandler, useState, SetStateAction } from 'react'
-import { Dialog } from '@headlessui/react'
-import Button from './PlayerControls/Button';
-import Link from 'next/link'
+import Button from "./PlayerControls/Button";
+import { Dialog } from "@headlessui/react";
+import Link from "next/link";
+import { Dispatch, MouseEventHandler, useState, SetStateAction } from "react";
 
 const Nip07InfoModal: React.FC<{
   setCommenterPubKey: Dispatch<SetStateAction<string | undefined>>;
   commenterPubKey?: string;
 }> = ({ setCommenterPubKey, commenterPubKey }) => {
-  let [isOpen, setIsOpen] = useState(false)
+  let [isOpen, setIsOpen] = useState(false);
 
   const clickHandler: MouseEventHandler<HTMLButtonElement> = async () => {
     try {
-      const pubKey = await window.nostr?.getPublicKey?.()
+      const pubKey = await window.nostr?.getPublicKey?.();
       if (pubKey) {
         setCommenterPubKey(pubKey);
         return;
       }
       // show modal if pubKey code above is undefined
-      setIsOpen(!isOpen)
+      setIsOpen(!isOpen);
     } catch (e) {
       // don't show modal if user rejects the NIP-07 extension's prompt
-      console.error(e)
+      console.error(e);
     }
-  }
+  };
 
   // if (commenterPubKey) return <></>;
 
@@ -37,10 +37,16 @@ const Nip07InfoModal: React.FC<{
       <Dialog open={isOpen} onClose={() => setIsOpen(false)}>
         <div className="fixed inset-0 bg-black/30" aria-hidden="true">
           <div className="fixed inset-0 flex items-center justify-center p-4">
-            <Dialog.Panel className="p-2 mx-auto max-w-md rounded bg-white">
+            <Dialog.Panel className="mx-auto max-w-md rounded bg-white p-2">
               <Dialog.Title className="pb-4 text-center">NIP-07</Dialog.Title>
               <Dialog.Description className="text-xs">
-                Looks like you don't have a NIP-07 extension installed. On mobile? Try this on a desktop browser with a NIP-07 extension (like Alby) installed. <Link href='https://github.com/nostr-protocol/nips/blob/master/07.md'>Click here</Link> to read more about NIP-07.
+                Looks like you don't have a NIP-07 extension installed. On
+                mobile? Try this on a desktop browser with a NIP-07 extension
+                (like Alby) installed.{" "}
+                <Link href="https://github.com/nostr-protocol/nips/blob/master/07.md">
+                  Click here
+                </Link>{" "}
+                to read more about NIP-07.
               </Dialog.Description>
               <Button
                 className="mx-auto mt-4 w-28 self-start bg-wavgray hover:tracking-wider"
@@ -53,7 +59,7 @@ const Nip07InfoModal: React.FC<{
         </div>
       </Dialog>
     </>
-  )
+  );
 };
 
 export default Nip07InfoModal;

--- a/src/pages/Nip07InfoModal.tsx
+++ b/src/pages/Nip07InfoModal.tsx
@@ -1,6 +1,7 @@
 import { Dispatch, MouseEventHandler, useState, SetStateAction } from 'react'
 import { Dialog } from '@headlessui/react'
 import Button from './PlayerControls/Button';
+import Link from 'next/link'
 
 const Nip07InfoModal: React.FC<{
   setCommenterPubKey: Dispatch<SetStateAction<string | undefined>>;
@@ -36,10 +37,10 @@ const Nip07InfoModal: React.FC<{
       <Dialog open={isOpen} onClose={() => setIsOpen(false)}>
         <div className="fixed inset-0 bg-black/30" aria-hidden="true">
           <div className="fixed inset-0 flex items-center justify-center p-4">
-            <Dialog.Panel className="mx-auto max-w-sm rounded bg-white">
-              <Dialog.Title>NIP-07</Dialog.Title>
-              <Dialog.Description>
-                Looks like you don't have a NIP-07 extension installed. On mobile? Try this on a desktop browser with a extension like Alby installed. Read more about NIP-07 here https://github.com/nostr-protocol/nips/blob/master/07.md
+            <Dialog.Panel className="p-2 mx-auto max-w-md rounded bg-white">
+              <Dialog.Title className="pb-4 text-center">NIP-07</Dialog.Title>
+              <Dialog.Description className="text-xs">
+                Looks like you don't have a NIP-07 extension installed. On mobile? Try this on a desktop browser with a extension like Alby installed. <Link href='https://github.com/nostr-protocol/nips/blob/master/07.md'>Click here</Link> to read more about NIP-07.
               </Dialog.Description>
               <Button
                 className="mx-auto mt-4 w-28 self-start bg-wavgray hover:tracking-wider"

--- a/src/pages/Nip07InfoModal.tsx
+++ b/src/pages/Nip07InfoModal.tsx
@@ -1,0 +1,53 @@
+import { Dispatch, MouseEventHandler, useState, SetStateAction } from 'react'
+import { Dialog } from '@headlessui/react'
+import Button from './PlayerControls/Button';
+
+const Nip07InfoModal: React.FC<{
+  setCommenterPubKey: Dispatch<SetStateAction<string | undefined>>;
+  commenterPubKey?: string;
+}> = ({ setCommenterPubKey, commenterPubKey }) => {
+  let [isOpen, setIsOpen] = useState(false)
+
+  const clickHandler: MouseEventHandler<HTMLButtonElement> = async () => {
+    try {
+      const pubKey = await window.nostr?.getPublicKey?.()
+      if (pubKey) {
+        setCommenterPubKey(pubKey);
+        return;
+      }
+    } catch (e) {
+      console.error(e)
+    }
+
+    setIsOpen(!isOpen)
+  }
+
+  // if (commenterPubKey) return <></>;
+
+  return (
+    <>
+      <Button
+        className="mx-auto mt-4 w-28 self-start bg-wavgray hover:tracking-wider"
+        clickHandler={clickHandler}
+      >
+        {commenterPubKey ? "LOGGED IN" : "NIP-07 LOGIN"}
+      </Button>
+      <Dialog open={isOpen} onClose={() => setIsOpen(false)}>
+        <Dialog.Panel>
+          <Dialog.Title>NIP-07</Dialog.Title>
+          <Dialog.Description>
+            Looks like you don't have a NIP-07 extension installed. On mobile? Try this on a desktop browser with a extension like Alby installed. Read more about NIP-07 here https://github.com/nostr-protocol/nips/blob/master/07.md
+            <Button
+              className="mx-auto mt-4 w-28 self-start bg-wavgray hover:tracking-wider"
+              clickHandler={() => setIsOpen(false)}
+            >
+              OK
+            </Button>
+          </Dialog.Description>
+        </Dialog.Panel>
+      </Dialog>
+    </>
+  )
+};
+
+export default Nip07InfoModal;

--- a/src/pages/Nip07InfoModal.tsx
+++ b/src/pages/Nip07InfoModal.tsx
@@ -40,7 +40,7 @@ const Nip07InfoModal: React.FC<{
             <Dialog.Panel className="p-2 mx-auto max-w-md rounded bg-white">
               <Dialog.Title className="pb-4 text-center">NIP-07</Dialog.Title>
               <Dialog.Description className="text-xs">
-                Looks like you don't have a NIP-07 extension installed. On mobile? Try this on a desktop browser with a extension like Alby installed. <Link href='https://github.com/nostr-protocol/nips/blob/master/07.md'>Click here</Link> to read more about NIP-07.
+                Looks like you don't have a NIP-07 extension installed. On mobile? Try this on a desktop browser with a NIP-07 extension (like Alby) installed. <Link href='https://github.com/nostr-protocol/nips/blob/master/07.md'>Click here</Link> to read more about NIP-07.
               </Dialog.Description>
               <Button
                 className="mx-auto mt-4 w-28 self-start bg-wavgray hover:tracking-wider"

--- a/src/pages/PlayerControls/Button.tsx
+++ b/src/pages/PlayerControls/Button.tsx
@@ -1,9 +1,9 @@
 import { ActionHandler } from "@/lib/shared";
-import { PropsWithChildren, useState } from "react";
+import { MouseEventHandler, PropsWithChildren, useState } from "react";
 
 const Button: React.FC<
   PropsWithChildren<{
-    clickHandler: ActionHandler;
+    clickHandler?: ActionHandler | MouseEventHandler<HTMLButtonElement>;
     className: string;
     buttonState?: ReturnType<typeof useState<boolean>>;
   }>

--- a/src/pages/WavmanPlayer.tsx
+++ b/src/pages/WavmanPlayer.tsx
@@ -11,6 +11,7 @@ import {
 } from "../lib/shared";
 import Links from "./Links";
 import Logo from "./Logo";
+import Nip07InfoModal from "./Nip07InfoModal";
 import Button from "./PlayerControls/Button";
 import PlayerControls from "./PlayerControls/PlayerControls";
 import Screen from "./Screen/Screen";
@@ -183,13 +184,6 @@ const WavmanPlayer: React.FC<{}> = ({}) => {
   };
   const [commenterPubKey, setCommenterPubKey] = useState<string | undefined>();
 
-  const setUserPubKey = () => {
-    window.nostr
-      ?.getPublicKey?.()
-      .then((pubKey) => setCommenterPubKey(pubKey))
-      .catch((e: string) => console.log(e));
-  };
-
   const confirmZapAmount = () => {
     setPageViewAndResetSelectedAction(ZAP_COMMENT_VIEW);
   };
@@ -284,12 +278,7 @@ const WavmanPlayer: React.FC<{}> = ({}) => {
           </div>
         </form>
       </FormProvider>
-      <Button
-        className="mx-auto mt-4 w-28 self-start bg-wavgray hover:tracking-wider"
-        clickHandler={setUserPubKey}
-      >
-        NIP-07 LOGIN
-      </Button>
+      <Nip07InfoModal setCommenterPubKey={setCommenterPubKey} commenterPubKey={commenterPubKey} /> 
       <div className="mx-auto mt-8 flex">
         <Links />
       </div>

--- a/src/pages/WavmanPlayer.tsx
+++ b/src/pages/WavmanPlayer.tsx
@@ -36,7 +36,9 @@ const randomSHA256String = (length: number) => {
     Math.floor(Math.random() * 36).toString(36)
   ).join("");
   const SHA256Regex = /[^A-Fa-f0-9-]/g;
-  const filteredChars = alphanumericString.replace(SHA256Regex, "").slice(0, length);
+  const filteredChars = alphanumericString
+    .replace(SHA256Regex, "")
+    .slice(0, length);
   return new Set(filteredChars);
 };
 
@@ -278,7 +280,10 @@ const WavmanPlayer: React.FC<{}> = ({}) => {
           </div>
         </form>
       </FormProvider>
-      <Nip07InfoModal setCommenterPubKey={setCommenterPubKey} commenterPubKey={commenterPubKey} /> 
+      <Nip07InfoModal
+        setCommenterPubKey={setCommenterPubKey}
+        commenterPubKey={commenterPubKey}
+      />
       <div className="mx-auto mt-8 flex">
         <Links />
       </div>


### PR DESCRIPTION
Add a popup modal that explains what to do if on mobile or if you don't already have a NIP-07 extension installed

User does not have a `window.nostr` available:
<img width="393" alt="Screen Shot 2023-04-17 at 3 56 56 PM" src="https://user-images.githubusercontent.com/14062229/232609034-622b0016-a27e-4d8e-81aa-c4b099de97ca.png">

User logs in successfully:
<img width="391" alt="Screen Shot 2023-04-17 at 3 53 39 PM" src="https://user-images.githubusercontent.com/14062229/232608677-3957611d-d8df-4c1e-ad62-20424df8bfa5.png">