### PR TITLE
Improve randomness

### DIFF
--- a/src/pages/LiftedWavmanPlayer.tsx
+++ b/src/pages/LiftedWavmanPlayer.tsx
@@ -33,6 +33,7 @@ const LiftedWavmanPlayer: React.FC<{}> = ({}) => {
     getHexCharacters(randomTrackFeatureFlag ? 4 : hexChars.length)
   );
   const [kind1Events, setKind1Events] = useState<Event[]>([]);
+  const [loadingEvents, setLoadingEvents] = useState(false);
   const { relay, useListEvents, useEventSubscription } = useRelay();
 
   // this should be switched to querying for a tags, but a tag values are different for each track
@@ -48,8 +49,13 @@ const LiftedWavmanPlayer: React.FC<{}> = ({}) => {
       },
     ];
     if (relay) {
+      setLoadingEvents(true);
       listEvents(relay, kind1Filter).then((events) => {
         events && setKind1Events((prev) => [...prev, ...events]);
+        setLoadingEvents(false);
+      }).catch((err) => {
+        console.error(err);
+        setLoadingEvents(false);
       });
     }
   }, [randomChars, trackPubKey, relay]);
@@ -59,7 +65,6 @@ const LiftedWavmanPlayer: React.FC<{}> = ({}) => {
   const [trackIndex, setTrackIndex] = useState(0);
 
   const pickRandomTrack = () => {
-    if (!kind1NowPlaying) return;
     if (randomTrackFeatureFlag) {
       setKind1NowPlaying(
         kind1Events[Math.floor(Math.random() * kind1Events.length)]
@@ -70,8 +75,9 @@ const LiftedWavmanPlayer: React.FC<{}> = ({}) => {
     }
   };
   useEffect(() => {
-    setKind1NowPlaying(kind1Events[0]);
-  }, [kind1Events]);
+    if (loadingEvents) return;
+    pickRandomTrack();
+  }, [loadingEvents]);
 
   // ZapReceipt Listener (aka zap comments)
   const {

--- a/src/pages/LiftedWavmanPlayer.tsx
+++ b/src/pages/LiftedWavmanPlayer.tsx
@@ -10,11 +10,11 @@ export interface Form {
   satAmount: number;
 }
 
-const KIND1_LIMIT = 10;
 const RANDOM_CHAR_FILTER_AMOUNT = 10;
 const randomTrackFeatureFlag = coerceEnvVarToBool(
   process.env.NEXT_PUBLIC_ENABLE_RANDOM_TRACKS
-);
+  );
+const KIND1_LIMIT = randomTrackFeatureFlag ? 100 : 10;
 const trackPubKey = process.env.NEXT_PUBLIC_TRACK_EVENT_PUBKEY || "";
 
 const hexChars = "0123456789abcdef";
@@ -97,7 +97,7 @@ const LiftedWavmanPlayer: React.FC<{}> = ({}) => {
       setKind1NowPlaying(kind1Events[0]);
     }
     if (trackIndex > (kind1Events.length - 1) && kind1NowPlaying) {
-      console.log(`you've listend to all the TextTrackList, please refresh the page to grab more :)`);
+      console.log(`you've listend to all of the tracks that were loaded, please refresh the page to load more :)`);
       // TODO pre-emptively grab more tracks when user is near end of list
       // we've seen all the tracks, make a call to grab another batch
       // setRandomChars(getHexCharacters(4));

--- a/src/pages/LiftedWavmanPlayer.tsx
+++ b/src/pages/LiftedWavmanPlayer.tsx
@@ -30,7 +30,7 @@ const LiftedWavmanPlayer: React.FC<{}> = ({}) => {
   // 4 characters returns ~90-130 tracks
   // will need to re-randomize this filter once the user reaches the end of the list
   const [randomChars, setRandomChars] = useState<string[]>(
-    getHexCharacters(randomTrackFeatureFlag ? 4 : hexChars.length)
+    getHexCharacters(randomTrackFeatureFlag ? 10 : hexChars.length)
   );
   const [batchOfKind1Events, setBatchOfKind1Events] = useState<Event[]>([]);
   const [kind1UnSeen, setKind1UnSeen] = useState<Event[]>([]);

--- a/src/pages/WavmanPlayer.tsx
+++ b/src/pages/WavmanPlayer.tsx
@@ -33,7 +33,6 @@ const randomTrackFeatureFlag = coerceEnvVarToBool(
 
 const WavmanPlayer: React.FC<{
   kind1NowPlaying?: Event;
-  kind1UnSeen: Event[];
   pickRandomTrack: () => void;
   zapReceipts: Event[];
   lastZapReceipt?: Event;
@@ -42,7 +41,6 @@ const WavmanPlayer: React.FC<{
   setPaymentRequest: (paymentRequest: string) => void;
 }> = ({
   kind1NowPlaying,
-  kind1UnSeen,
   pickRandomTrack,
   zapReceipts,
   lastZapReceipt,
@@ -52,11 +50,10 @@ const WavmanPlayer: React.FC<{
 }) => {
   useEffect(() => {
     // runs only on startup
-    if (currentPage === SPLASH_VIEW && kind1UnSeen.length > 0) {
-      pickRandomTrack();
+    if (currentPage === SPLASH_VIEW && kind1NowPlaying) {
       setCurrentPage(PLAYER_VIEW);
     }
-  }, [kind1UnSeen]);
+  }, [kind1NowPlaying]);
 
   const skipHandler = () => {
     pickRandomTrack();

--- a/src/pages/WavmanPlayer.tsx
+++ b/src/pages/WavmanPlayer.tsx
@@ -171,7 +171,12 @@ const WavmanPlayer: React.FC<{
 
   const [kind32123NowPlaying] = kind32123Events || [];
   const trackContent: WavlakeEventContent = JSON.parse(
-    kind32123NowPlaying?.content || "{}"
+    kind32123NowPlaying?.content || JSON.stringify({
+      title: "",
+      enclosure: "",
+      artist: "",
+      link: "",
+    })
   );
 
   return (

--- a/src/pages/WavmanPlayer.tsx
+++ b/src/pages/WavmanPlayer.tsx
@@ -33,6 +33,7 @@ const randomTrackFeatureFlag = coerceEnvVarToBool(
 
 const WavmanPlayer: React.FC<{
   kind1NowPlaying?: Event;
+  kind1UnSeen: Event[];
   pickRandomTrack: () => void;
   zapReceipts: Event[];
   lastZapReceipt?: Event;
@@ -41,6 +42,7 @@ const WavmanPlayer: React.FC<{
   setPaymentRequest: (paymentRequest: string) => void;
 }> = ({
   kind1NowPlaying,
+  kind1UnSeen,
   pickRandomTrack,
   zapReceipts,
   lastZapReceipt,
@@ -50,10 +52,11 @@ const WavmanPlayer: React.FC<{
 }) => {
   useEffect(() => {
     // runs only on startup
-    if (currentPage === SPLASH_VIEW && kind1NowPlaying) {
+    if (currentPage === SPLASH_VIEW && kind1UnSeen.length > 0) {
+      pickRandomTrack();
       setCurrentPage(PLAYER_VIEW);
     }
-  }, [kind1NowPlaying]);
+  }, [kind1UnSeen]);
 
   const skipHandler = () => {
     pickRandomTrack();

--- a/src/pages/WavmanPlayer.tsx
+++ b/src/pages/WavmanPlayer.tsx
@@ -170,13 +170,14 @@ const WavmanPlayer: React.FC<{
   }, [kind1NowPlaying, relay]);
 
   const [kind32123NowPlaying] = kind32123Events || [];
+  const defaultTrackInfo: Partial<WavlakeEventContent> = {
+    title: "",
+    enclosure: "",
+    creator: "",
+    link: "",
+  }
   const trackContent: WavlakeEventContent = JSON.parse(
-    kind32123NowPlaying?.content || JSON.stringify({
-      title: "",
-      enclosure: "",
-      artist: "",
-      link: "",
-    })
+    kind32123NowPlaying?.content || JSON.stringify(defaultTrackInfo)
   );
 
   return (


### PR DESCRIPTION
improved randomness, was previously selecting the first song in the list

added a default track content object to display while loading, was previously showing `undefined`

order of events for kind1 tracks:

1. grab batch of tracks from relay
2. shuffle the list
3. add the list to the end of `kind1Events` (starts off empty)
4. set the now playing track to index 0
5. user clicks next, increment the track index and set the next now playing track
6. when the user reaches the end of the list, a console log will fire directing the user to refresh

Item 6 will be a future feature that will auto grab another batch of tracks, shuffle them, and add them to `kind1Events`. There is still the potential of grabbing tracks (the second batch) that have already been played. Will need to figure out a way to keep track of seen tracks and filter them out. 