### PR TITLE
Fix zapping for wavlake lnurl

### DIFF
--- a/src/nostr/zapUtils.ts
+++ b/src/nostr/zapUtils.ts
@@ -128,7 +128,9 @@ export const getLNURLFromEvent = (event: Event): string | undefined => {
   const [username, domain] = zapAddress.split("@");
   if (!username || !domain) return;
 
-  return `${protocol}://${domain}/.well-known/lnurlp/${username}`;
+  // this is a hack to address the move of the wavlake endpoint from www.wavlake.com to wavlake.com
+  // the proper fix is to update the events to include the new domain
+  return `${protocol}://${domain.replace("www.", "")}/.well-known/lnurlp/${username}`;
 };
 
 export const fetchLNURLInfo = async (


### PR DESCRIPTION
The wavlake lnurl endpoint has moved from www.wavlake.com to wavlake.com.

The proper fix for this is to update the published events. Since wavman only consumes wavlake events, this hack will enable zaps to continue working while the music event format is still in flux.